### PR TITLE
Disable cloudflare autoupdate

### DIFF
--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -10,6 +10,8 @@ RUN wget -qO /usr/bin/cloudflared $(wget -qO- https://api.github.com/repos/cloud
 FROM alpine
 LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
 
+ENV NO_AUTOUPDATE=true
+
 ARG PUID=1000
 ARG PGID=1000
 RUN addgroup -S -g ${PGID} app && adduser -S -u ${PUID} -G app app


### PR DESCRIPTION
Since this is a dockerized version we don't want the autoupdate mechanism to kick in. Disabling by default so you don't have to set the env var each time