### PR TITLE
Add OCI labels to all Dockerfiles and configure GitHub Actions build args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -37,12 +39,18 @@ jobs:
           tags: maxcanna/ffmpeg:latest,maxcanna/ffmpeg:${{ env.FFMPEG_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.FFMPEG_VERSION }}
   subliminal:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -68,12 +76,18 @@ jobs:
           tags: maxcanna/subliminal:latest,maxcanna/subliminal:${{ env.SUBLIMINAL_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.SUBLIMINAL_VERSION }}
   caddy:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -99,12 +113,18 @@ jobs:
           tags: maxcanna/caddy:latest,maxcanna/caddy:${{ env.CADDY_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.CADDY_VERSION }}
   transmission:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -130,12 +150,18 @@ jobs:
           tags: maxcanna/transmission:latest,maxcanna/transmission:${{ env.TRANSMISSION_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.TRANSMISSION_VERSION }}
   minidlna:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -161,12 +187,18 @@ jobs:
           tags: maxcanna/minidlna:latest,maxcanna/minidlna:${{ env.MINIDLNA_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.MINIDLNA_VERSION }}
   openvpn:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -192,12 +224,18 @@ jobs:
           tags: maxcanna/openvpn:latest,maxcanna/openvpn:${{ env.OPENVPN_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.OPENVPN_VERSION }}
   cloudflared:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -223,12 +261,18 @@ jobs:
           tags: maxcanna/cloudflared:latest,maxcanna/cloudflared:${{ env.CLOUDFLARED_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.CLOUDFLARED_VERSION }}
   airconnect:
     runs-on: ubuntu-latest
     steps:
       - name: Set env vars
         run: |
           echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
+          echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -254,3 +298,7 @@ jobs:
           tags: maxcanna/airconnect:latest,maxcanna/airconnect:${{ env.AIRCONNECT_VERSION }}
           push: ${{ env.DOCKER_PUSH }}
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            REVISION=${{ env.REVISION }}
+            VERSION=${{ env.AIRCONNECT_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Detect ffmpeg version
         run: |
           echo FFMPEG_VERSION=$(docker run --rm maxcanna/ffmpeg:version -version | xargs | cut -d ' ' -f 3) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/ffmpeg:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build ffmpeg
         uses: docker/build-push-action@v4
         with:
@@ -43,6 +44,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.FFMPEG_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   subliminal:
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +71,7 @@ jobs:
       - name: Detect subliminal version
         run: |
           echo SUBLIMINAL_VERSION=$(docker run --rm maxcanna/subliminal:version --version | cut -d ' ' -f 3) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/subliminal:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build subliminal
         uses: docker/build-push-action@v4
         with:
@@ -80,6 +83,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.SUBLIMINAL_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   caddy:
     runs-on: ubuntu-latest
     steps:
@@ -106,6 +110,7 @@ jobs:
       - name: Export caddy version
         run: |
           echo CADDY_VERSION=$(docker run --rm maxcanna/caddy:version version | cut -d ' ' -f 1) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/caddy:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build caddy
         uses: docker/build-push-action@v4
         with:
@@ -117,6 +122,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.CADDY_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   transmission:
     runs-on: ubuntu-latest
     steps:
@@ -143,6 +149,7 @@ jobs:
       - name: Detect transmission version
         run: |
           echo TRANSMISSION_VERSION=$(docker run --rm maxcanna/transmission:version --version 2>&1 | xargs | cut -d ' ' -f 2) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/transmission:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build transmission
         uses: docker/build-push-action@v4
         with:
@@ -154,6 +161,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.TRANSMISSION_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   minidlna:
     runs-on: ubuntu-latest
     steps:
@@ -180,6 +188,7 @@ jobs:
       - name: Detect minidlna version
         run: |
           echo MINIDLNA_VERSION=$(docker run --rm maxcanna/minidlna:version -V | cut -d ' ' -f 2) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/minidlna:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build minidlna
         uses: docker/build-push-action@v4
         with:
@@ -191,6 +200,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.MINIDLNA_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   openvpn:
     runs-on: ubuntu-latest
     steps:
@@ -217,6 +227,7 @@ jobs:
       - name: Detect openvpn version
         run: |
           echo OPENVPN_VERSION=$(docker run --rm --entrypoint openvpn maxcanna/openvpn:version --version | xargs | cut -d ' ' -f 2) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/openvpn:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build openvpn
         uses: docker/build-push-action@v4
         with:
@@ -228,6 +239,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.OPENVPN_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   cloudflared:
     runs-on: ubuntu-latest
     steps:
@@ -254,6 +266,7 @@ jobs:
       - name: Detect cloudflared version
         run: |
           echo CLOUDFLARED_VERSION=$(docker run --rm maxcanna/cloudflared:version version | cut -d ' ' -f 3) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/cloudflared:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build cloudflared
         uses: docker/build-push-action@v4
         with:
@@ -265,6 +278,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.CLOUDFLARED_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
   airconnect:
     runs-on: ubuntu-latest
     steps:
@@ -291,6 +305,7 @@ jobs:
       - name: Detect airconnect version
         run: |
           echo AIRCONNECT_VERSION=$(docker run --rm maxcanna/airconnect:version | xargs | cut -d ' ' -f 1) >> $GITHUB_ENV
+          echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/airconnect:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build airconnect
         uses: docker/build-push-action@v4
         with:
@@ -302,3 +317,4 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             REVISION=${{ env.REVISION }}
             VERSION=${{ env.AIRCONNECT_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build ffmpeg version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:ffmpeg"
           tags: maxcanna/ffmpeg:version
@@ -34,7 +34,7 @@ jobs:
           echo FFMPEG_VERSION=$(docker run --rm maxcanna/ffmpeg:version -version | xargs | cut -d ' ' -f 3) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/ffmpeg:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build ffmpeg
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:ffmpeg"
           tags: maxcanna/ffmpeg:latest,maxcanna/ffmpeg:${{ env.FFMPEG_VERSION }}
@@ -54,16 +54,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build subliminal version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:subliminal"
           tags: maxcanna/subliminal:version
@@ -73,7 +73,7 @@ jobs:
           echo SUBLIMINAL_VERSION=$(docker run --rm maxcanna/subliminal:version --version | cut -d ' ' -f 3) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/subliminal:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build subliminal
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:subliminal"
           tags: maxcanna/subliminal:latest,maxcanna/subliminal:${{ env.SUBLIMINAL_VERSION }}
@@ -93,16 +93,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Detect caddy version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:caddy"
           tags: maxcanna/caddy:version
@@ -112,7 +112,7 @@ jobs:
           echo CADDY_VERSION=$(docker run --rm maxcanna/caddy:version version | cut -d ' ' -f 1) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/caddy:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build caddy
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:caddy"
           tags: maxcanna/caddy:latest,maxcanna/caddy:${{ env.CADDY_VERSION }}
@@ -132,16 +132,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build transmission version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:transmission"
           tags: maxcanna/transmission:version
@@ -151,7 +151,7 @@ jobs:
           echo TRANSMISSION_VERSION=$(docker run --rm maxcanna/transmission:version --version 2>&1 | xargs | cut -d ' ' -f 2) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/transmission:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build transmission
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:transmission"
           tags: maxcanna/transmission:latest,maxcanna/transmission:${{ env.TRANSMISSION_VERSION }}
@@ -171,16 +171,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build minidlna version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:minidlna"
           tags: maxcanna/minidlna:version
@@ -190,7 +190,7 @@ jobs:
           echo MINIDLNA_VERSION=$(docker run --rm maxcanna/minidlna:version -V | cut -d ' ' -f 2) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/minidlna:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build minidlna
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:minidlna"
           tags: maxcanna/minidlna:latest,maxcanna/minidlna:${{ env.MINIDLNA_VERSION }}
@@ -210,16 +210,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build openvpn version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:openvpn"
           tags: maxcanna/openvpn:version
@@ -229,7 +229,7 @@ jobs:
           echo OPENVPN_VERSION=$(docker run --rm --entrypoint openvpn maxcanna/openvpn:version --version | xargs | cut -d ' ' -f 2) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/openvpn:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build openvpn
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:openvpn"
           tags: maxcanna/openvpn:latest,maxcanna/openvpn:${{ env.OPENVPN_VERSION }}
@@ -249,16 +249,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build cloudflared version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:cloudflared"
           tags: maxcanna/cloudflared:version
@@ -268,7 +268,7 @@ jobs:
           echo CLOUDFLARED_VERSION=$(docker run --rm maxcanna/cloudflared:version version | cut -d ' ' -f 3) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/cloudflared:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build cloudflared
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:cloudflared"
           tags: maxcanna/cloudflared:latest,maxcanna/cloudflared:${{ env.CLOUDFLARED_VERSION }}
@@ -288,16 +288,16 @@ jobs:
           echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_ENV
           echo REVISION=$(git rev-parse HEAD) >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build airconnect version
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:airconnect"
           tags: maxcanna/airconnect:version
@@ -307,7 +307,7 @@ jobs:
           echo AIRCONNECT_VERSION=$(docker run --rm maxcanna/airconnect:version | xargs | cut -d ' ' -f 1) >> $GITHUB_ENV
           echo ALPINE_VERSION=$(docker run --rm --entrypoint cat maxcanna/airconnect:version /etc/alpine-release) >> $GITHUB_ENV
       - name: Build airconnect
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:airconnect"
           tags: maxcanna/airconnect:latest,maxcanna/airconnect:${{ env.AIRCONNECT_VERSION }}

--- a/airconnect/Dockerfile
+++ b/airconnect/Dockerfile
@@ -15,7 +15,22 @@ RUN wget -qO airconnect.zip $(wget -qO- https://api.github.com/repos/philippe44/
     && chmod u+x /usr/bin/aircast /usr/bin/airupnp
 
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="airconnect" \
+      org.opencontainers.image.description="airconnect (latest version on alpine:latest)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/airconnect/Dockerfile
+++ b/airconnect/Dockerfile
@@ -19,6 +19,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -30,7 +31,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="airconnect" \
-      org.opencontainers.image.description="airconnect (latest version on alpine:latest)"
+      org.opencontainers.image.description="airconnect ($VERSION on alpine:$ALPINE_VERSION)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -12,6 +12,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -23,7 +24,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="caddy" \
-      org.opencontainers.image.description="caddy (latest version on alpine:latest)"
+      org.opencontainers.image.description="caddy ($VERSION on alpine:$ALPINE_VERSION)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -8,7 +8,22 @@ RUN wget -qO- $(wget -qO- https://api.github.com/repos/caddyserver/caddy/release
     && chmod u+x /usr/bin/caddy
 
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="caddy" \
+      org.opencontainers.image.description="caddy (latest version on alpine:latest)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -12,6 +12,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -23,7 +24,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="cloudflared" \
-      org.opencontainers.image.description="cloudflared (latest version on alpine:latest)"
+      org.opencontainers.image.description="cloudflared ($VERSION on alpine:$ALPINE_VERSION)"
 
 ENV NO_AUTOUPDATE=true
 

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -8,7 +8,22 @@ RUN wget -qO /usr/bin/cloudflared $(wget -qO- https://api.github.com/repos/cloud
     && chmod u+x /usr/bin/cloudflared
 
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="cloudflared" \
+      org.opencontainers.image.description="cloudflared (latest version on alpine:latest)"
 
 ENV NO_AUTOUPDATE=true
 

--- a/ffmpeg/Dockerfile
+++ b/ffmpeg/Dockerfile
@@ -1,5 +1,20 @@
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="ffmpeg" \
+      org.opencontainers.image.description="ffmpeg (latest version on alpine:latest)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/ffmpeg/Dockerfile
+++ b/ffmpeg/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -14,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="ffmpeg" \
-      org.opencontainers.image.description="ffmpeg (latest version on alpine:latest)"
+      org.opencontainers.image.description="ffmpeg ($VERSION on alpine:$ALPINE_VERSION)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/minidlna/Dockerfile
+++ b/minidlna/Dockerfile
@@ -1,5 +1,20 @@
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="minidlna" \
+      org.opencontainers.image.description="minidlna (latest version on alpine:latest)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/minidlna/Dockerfile
+++ b/minidlna/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -14,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="minidlna" \
-      org.opencontainers.image.description="minidlna (latest version on alpine:latest)"
+      org.opencontainers.image.description="minidlna ($VERSION on alpine:$ALPINE_VERSION)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -1,5 +1,20 @@
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="openvpn" \
+      org.opencontainers.image.description="openvpn (latest version on alpine:latest)"
 
 RUN apk add --no-cache --update openvpn iptables openssl
 

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -14,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="openvpn" \
-      org.opencontainers.image.description="openvpn (latest version on alpine:latest)"
+      org.opencontainers.image.description="openvpn ($VERSION on alpine:$ALPINE_VERSION)"
 
 RUN apk add --no-cache --update openvpn iptables openssl
 

--- a/subliminal/Dockerfile
+++ b/subliminal/Dockerfile
@@ -3,6 +3,7 @@ FROM python:alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -14,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="subliminal" \
-      org.opencontainers.image.description="subliminal (latest version on alpine:latest)"
+      org.opencontainers.image.description="subliminal ($VERSION on alpine:$ALPINE_VERSION)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/subliminal/Dockerfile
+++ b/subliminal/Dockerfile
@@ -1,5 +1,20 @@
 FROM python:alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="subliminal" \
+      org.opencontainers.image.description="subliminal (latest version on alpine:latest)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
+ARG ALPINE_VERSION
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
@@ -14,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.title="transmission" \
-      org.opencontainers.image.description="transmission (latest version on alpine:latest)"
+      org.opencontainers.image.description="transmission ($VERSION on alpine:$ALPINE_VERSION)"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -1,5 +1,20 @@
 FROM alpine
-LABEL maintainer="Massimiliano Cannarozzo <massi@massi.dev>"
+
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Massimiliano Cannarozzo <massi@massi.dev>" \
+      org.opencontainers.image.url="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.documentation="https://github.com/maxcanna/dockerfiles/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/maxcanna/dockerfiles" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.vendor="Massimiliano Cannarozzo" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.title="transmission" \
+      org.opencontainers.image.description="transmission (latest version on alpine:latest)"
 
 ARG PUID=1000
 ARG PGID=1000


### PR DESCRIPTION
Add OCI labels to all Dockerfiles and configure GitHub Actions build args

Replaces the legacy `maintainer` label with standard `org.opencontainers.image.*`
annotations in all Dockerfiles. Updates the `.github/workflows/ci.yml` file to
pass `BUILD_DATE`, `REVISION`, and `VERSION` as build arguments to each image build
job, enabling dynamic OCI label values. Includes descriptions based on the README.md
format for each image.